### PR TITLE
Import Combine for AppEnvironment

### DIFF
--- a/Audera/AppEnvironment.swift
+++ b/Audera/AppEnvironment.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftData
+import Combine
 
 @MainActor
 final class AppEnvironment: ObservableObject {


### PR DESCRIPTION
## Summary
- add Combine import to AppEnvironment so ObservableObject gains its default publisher

## Testing
- `xcodebuild -scheme Audera -project Audera.xcodeproj -target Audera build` *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9040b83083329e41814fd770b000