### PR TITLE
Fix NoiseMonitor concurrency issues and add Combine import

### DIFF
--- a/Audera/ViewModels/HistoryViewModel.swift
+++ b/Audera/ViewModels/HistoryViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 @MainActor
 final class HistoryViewModel: ObservableObject {


### PR DESCRIPTION
## Summary
- add the Combine import to HistoryViewModel so ObservableObject publishes correctly
- make NoiseMonitor's default scheduler conform to the main-actor protocol by making it a class and annotating the initializer
- explicitly return Void from prepareRecorderIfNeeded's continuation to satisfy generic inference

## Testing
- `xcodebuild -scheme Audera -project Audera.xcodeproj -target Audera build` *(fails: `xcodebuild` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc926228ac8332884f8038e258763a