### PR TITLE
Require explicit scheduler when creating NoiseMonitor

### DIFF
--- a/Audera/AppEnvironment.swift
+++ b/Audera/AppEnvironment.swift
@@ -18,7 +18,9 @@ final class AppEnvironment: ObservableObject {
     init(container: ModelContainer) {
         analytics = NoiseAnalytics()
         dataController = NoiseDataController(container: container, analytics: analytics)
-        noiseMonitor = NoiseMonitor(dataController: dataController, configuration: analytics.configuration)
+        noiseMonitor = NoiseMonitor(dataController: dataController,
+                                    configuration: analytics.configuration,
+                                    scheduler: NoiseMonitor.Scheduler())
         do {
             try dataController.updateSummary(for: Date())
         } catch {

--- a/Audera/Services/NoiseMonitor.swift
+++ b/Audera/Services/NoiseMonitor.swift
@@ -64,13 +64,22 @@ final class NoiseMonitor: NSObject, ObservableObject {
 
     @MainActor
     init(dataController: NoiseDataController,
-         configuration: NoiseAnalytics.Configuration = .default,
-         scheduler: NoiseMonitorScheduling = Scheduler()) {
+         configuration: NoiseAnalytics.Configuration,
+         scheduler: NoiseMonitorScheduling) {
         self.dataController = dataController
         self.configuration = configuration
         self.scheduler = scheduler
         super.init()
         NoiseMonitor.shared = self
+    }
+
+    @MainActor
+    convenience init(dataController: NoiseDataController) {
+        let configuration = NoiseAnalytics.Configuration.default
+        let scheduler = Scheduler()
+        self.init(dataController: dataController,
+                  configuration: configuration,
+                  scheduler: scheduler)
     }
 
     // MARK: - Lifecycle


### PR DESCRIPTION
## Summary
- require explicit configuration and scheduler parameters for the NoiseMonitor designated initializer
- add a main-actor convenience initializer that provides the default configuration and scheduler
- update AppEnvironment to pass an explicit scheduler when constructing the monitor

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9c3879688332982ac8fcac4602f6