### PR TITLE
Fix chart axis label usage

### DIFF
--- a/Audera/Views/DashboardView.swift
+++ b/Audera/Views/DashboardView.swift
@@ -108,9 +108,9 @@ struct DashboardView: View {
                 }
                 .chartXAxis {
                     AxisMarks(values: .stride(by: .hour, count: 3)) { value in
-                        if let date = value.as(Date.self) {
+                        if value.as(Date.self) != nil {
                             AxisGridLine()
-                            AxisValueLabel(date, format: .dateTime.hour(.defaultDigits(amPM: .abbreviated)))
+                            AxisValueLabel(format: .dateTime.hour(.defaultDigits(amPM: .abbreviated)))
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- replace the unsupported `AxisValueLabel(date:format:)` call in the noise timeline chart
- rely on the format-based initializer so the x-axis continues to show hourly labels without argument label errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc9ea84e148332ab1cb414eabd739f