### PR TITLE
Fix chart background overlay positioning for ChartProxy changes

### DIFF
--- a/Audera/Views/DashboardView.swift
+++ b/Audera/Views/DashboardView.swift
@@ -137,10 +137,10 @@ struct DashboardView: View {
                                 let plotFrame = geometry[plotAreaAnchor]
 
                                 if plotFrame != .null,
-                                   let quietBottom = proxy.position(forY: 0, in: geometry),
-                                   let quietTop = proxy.position(forY: 40, in: geometry),
-                                   let moderateTop = proxy.position(forY: 70, in: geometry),
-                                   let loudTop = proxy.position(forY: 85, in: geometry) {
+                                   let quietBottom = proxy.position(forY: 0, in: plotFrame),
+                                   let quietTop = proxy.position(forY: 40, in: plotFrame),
+                                   let moderateTop = proxy.position(forY: 70, in: plotFrame),
+                                   let loudTop = proxy.position(forY: 85, in: plotFrame) {
 
                                     let quietHeight = max(0, quietBottom - quietTop)
                                     let moderateHeight = max(0, quietTop - moderateTop)
@@ -149,17 +149,17 @@ struct DashboardView: View {
                                     Rectangle()
                                         .fill(Color.green.opacity(0.1))
                                         .frame(width: plotFrame.width, height: quietHeight)
-                                        .offset(x: plotFrame.minX, y: quietTop)
+                                        .offset(x: plotFrame.minX, y: plotFrame.minY + quietTop)
 
                                     Rectangle()
                                         .fill(Color.orange.opacity(0.08))
                                         .frame(width: plotFrame.width, height: moderateHeight)
-                                        .offset(x: plotFrame.minX, y: moderateTop)
+                                        .offset(x: plotFrame.minX, y: plotFrame.minY + moderateTop)
 
                                     Rectangle()
                                         .fill(Color.red.opacity(0.06))
                                         .frame(width: plotFrame.width, height: loudHeight)
-                                        .offset(x: plotFrame.minX, y: loudTop)
+                                        .offset(x: plotFrame.minX, y: plotFrame.minY + loudTop)
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- update the chart background to use the supported `ChartProxy.position(forY:in:)` overload with the plot frame
- adjust the overlay offsets so the quiet/moderate/loud regions stay aligned with the plot area

## Testing
- Not run (Xcode is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cca37fafa48332942fd69043cd5558