### PR TITLE
Fix chart background shading calculation

### DIFF
--- a/Audera/Views/DashboardView.swift
+++ b/Audera/Views/DashboardView.swift
@@ -136,30 +136,42 @@ struct DashboardView: View {
                             if let plotAreaAnchor = proxy.plotAreaFrame {
                                 let plotFrame = geometry[plotAreaAnchor]
 
-                                if plotFrame != .null,
-                                   let quietBottom = proxy.position(forY: 0, in: plotFrame),
-                                   let quietTop = proxy.position(forY: 40, in: plotFrame),
-                                   let moderateTop = proxy.position(forY: 70, in: plotFrame),
-                                   let loudTop = proxy.position(forY: 85, in: plotFrame) {
+                                if plotFrame != .null {
+                                    let domainLower: CGFloat = 0
+                                    let domainUpper: CGFloat = 100
+                                    let domainRange = domainUpper - domainLower
 
-                                    let quietHeight = max(0, quietBottom - quietTop)
-                                    let moderateHeight = max(0, quietTop - moderateTop)
-                                    let loudHeight = max(0, moderateTop - loudTop)
+                                    if domainRange > 0 {
+                                        let yPosition: (CGFloat) -> CGFloat = { value in
+                                            let clampedValue = min(max(value, domainLower), domainUpper)
+                                            let normalized = (clampedValue - domainLower) / domainRange
+                                            return plotFrame.height * (1 - normalized)
+                                        }
 
-                                    Rectangle()
-                                        .fill(Color.green.opacity(0.1))
-                                        .frame(width: plotFrame.width, height: quietHeight)
-                                        .offset(x: plotFrame.minX, y: plotFrame.minY + quietTop)
+                                        let quietBottom = plotFrame.height
+                                        let quietTop = yPosition(40)
+                                        let moderateTop = yPosition(70)
+                                        let loudTop = yPosition(85)
 
-                                    Rectangle()
-                                        .fill(Color.orange.opacity(0.08))
-                                        .frame(width: plotFrame.width, height: moderateHeight)
-                                        .offset(x: plotFrame.minX, y: plotFrame.minY + moderateTop)
+                                        let quietHeight = max(0, quietBottom - quietTop)
+                                        let moderateHeight = max(0, quietTop - moderateTop)
+                                        let loudHeight = max(0, moderateTop - loudTop)
 
-                                    Rectangle()
-                                        .fill(Color.red.opacity(0.06))
-                                        .frame(width: plotFrame.width, height: loudHeight)
-                                        .offset(x: plotFrame.minX, y: plotFrame.minY + loudTop)
+                                        Rectangle()
+                                            .fill(Color.green.opacity(0.1))
+                                            .frame(width: plotFrame.width, height: quietHeight)
+                                            .offset(x: plotFrame.minX, y: plotFrame.minY + quietTop)
+
+                                        Rectangle()
+                                            .fill(Color.orange.opacity(0.08))
+                                            .frame(width: plotFrame.width, height: moderateHeight)
+                                            .offset(x: plotFrame.minX, y: plotFrame.minY + moderateTop)
+
+                                        Rectangle()
+                                            .fill(Color.red.opacity(0.06))
+                                            .frame(width: plotFrame.width, height: loudHeight)
+                                            .offset(x: plotFrame.minX, y: plotFrame.minY + loudTop)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- replace the use of `ChartProxy.position(forY:in:)` in `DashboardView` with manual y-position math based on the known chart domain
- keep the background highlighting logic intact while avoiding the extra `in` argument compile error

## Testing
- not run (requires iOS build tools unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cca62a94a083328b6fb044c9c0335c